### PR TITLE
Feat: better handle csproj files

### DIFF
--- a/back/src/changing_dot/checks/check_solution_validity.py
+++ b/back/src/changing_dot/checks/check_solution_validity.py
@@ -1,3 +1,4 @@
+import os
 from typing import TYPE_CHECKING
 
 from changing_dot.changing_graph.changing_graph import ChangingGraph
@@ -90,4 +91,16 @@ def simple_check_solution_validity_block(
         # TODO [] does not make it work with omnisharp errormanager
         compile_errors = error_manager.get_compile_errors([], observer)
 
-    return problem_node["error"] not in compile_errors
+    # Do not take project_name into account
+    return {
+        "file_path": os.path.abspath(problem_node["error"]["file_path"]),
+        "pos": problem_node["error"]["pos"],
+        "text": problem_node["error"]["text"],
+    } not in [
+        {
+            "file_path": os.path.abspath(error["file_path"]),
+            "pos": error["pos"],
+            "text": error["text"],
+        }
+        for error in compile_errors
+    ]

--- a/back/src/changing_dot/dependency_graph/dependency_graph.py
+++ b/back/src/changing_dot/dependency_graph/dependency_graph.py
@@ -119,6 +119,10 @@ class DependencyGraph:
             node = self.get_node(edit.block_id)
             assert node.file_path == edit.file_path, "This block is not in this file"
 
+            assert edit.before.replace(" ", "").replace("\n", "") in node.text.replace(
+                " ", ""
+            ).replace("\n", ""), "The before does not match the text in block"
+
             # Check that the files have actually been changed before updating graph
             assert edit.after.replace(" ", "").replace(
                 "\n", ""

--- a/back/src/changing_dot/dependency_graph/dependency_graph.py
+++ b/back/src/changing_dot/dependency_graph/dependency_graph.py
@@ -282,7 +282,9 @@ class DependencyGraph:
             )
             if ast_node.text is not None
             and isinstance(ast_node.text, bytes)
-            and ast_node.text.decode("utf-8").replace(" ", "").replace("\n", "")
+            and remove_comments(ast_node.text.decode("utf-8"))
+            .replace(" ", "")
+            .replace("\n", "")
             == remove_comments(text).replace(" ", "").replace("\n", "")
         ]
 

--- a/back/src/changing_dot/dependency_graph/language_matchers.py
+++ b/back/src/changing_dot/dependency_graph/language_matchers.py
@@ -41,14 +41,23 @@ class PythonMatcher(ILanguageMatcher):
         return ast_node.type in python_node_type_to_terminal[node_type]
 
 
-xml_node_type_to_terminal: NodeTypeToTerminal = {
-    "Class": [],
-    "Method": ["element"],
-    "Field": [],
-    "Import": [],
-}
-
-
 class XmlMatcher(ILanguageMatcher):
     def match_class(self, node_type: DependencyGraphNodeType, ast_node: Node) -> bool:
-        return ast_node.type in xml_node_type_to_terminal[node_type]
+        if node_type != "Method":
+            return False
+        return ast_node.type == "element"
+
+
+class CsProjMatcher(ILanguageMatcher):
+    def match_class(self, node_type: DependencyGraphNodeType, ast_node: Node) -> bool:
+        if node_type != "Method":
+            return False
+        return ast_node.type == "element" and self.has_element_descendant(ast_node)
+
+    def has_element_descendant(self, node: Node) -> bool:
+        for child in node.children:
+            if child.type == "element":
+                return True
+            if self.has_element_descendant(child):
+                return True
+        return False

--- a/back/src/changing_dot/dependency_graph/language_matchers.py
+++ b/back/src/changing_dot/dependency_graph/language_matchers.py
@@ -1,0 +1,54 @@
+from changing_dot.dependency_graph.types import (
+    DependencyGraphNodeType,
+    NodeTypeToTerminal,
+)
+from tree_sitter import Node
+
+
+class ILanguageMatcher:
+    def match_class(self, node_type: DependencyGraphNodeType, ast_node: Node) -> bool:
+        raise NotImplementedError()
+
+
+class EmptyMatcher(ILanguageMatcher):
+    def match_class(self, node_type: DependencyGraphNodeType, ast_node: Node) -> bool:
+        return False
+
+
+c_sharp_node_type_to_terminal: NodeTypeToTerminal = {
+    "Class": ["class_declaration"],
+    "Method": ["method_declaration", "constructor_declaration"],
+    "Field": ["field_declaration", "property_declaration"],
+    "Import": ["using_directive"],
+}
+
+
+class CSharpMatcher(ILanguageMatcher):
+    def match_class(self, node_type: DependencyGraphNodeType, ast_node: Node) -> bool:
+        return ast_node.type in c_sharp_node_type_to_terminal[node_type]
+
+
+python_node_type_to_terminal: NodeTypeToTerminal = {
+    "Class": ["class_definition"],
+    "Method": ["function_definition"],
+    "Field": [],
+    "Import": ["import_statement"],
+}
+
+
+class PythonMatcher(ILanguageMatcher):
+    def match_class(self, node_type: DependencyGraphNodeType, ast_node: Node) -> bool:
+        return ast_node.type in python_node_type_to_terminal[node_type]
+
+
+xml_node_type_to_terminal: NodeTypeToTerminal = {
+    "Class": [],
+    "Method": ["element"],
+    "Field": [],
+    "Import": [],
+}
+
+
+class XmlMatcher(ILanguageMatcher):
+    def match_class(self, node_type: DependencyGraphNodeType, ast_node: Node) -> bool:
+        return ast_node.type in xml_node_type_to_terminal[node_type]

--- a/back/src/changing_dot/dependency_graph/node_type_to_terminal.py
+++ b/back/src/changing_dot/dependency_graph/node_type_to_terminal.py
@@ -1,50 +1,15 @@
-from typing import Literal
-
 import tree_sitter_c_sharp as tscsharp
+from changing_dot.dependency_graph.language_matchers import (
+    CSharpMatcher,
+    EmptyMatcher,
+    ILanguageMatcher,
+    PythonMatcher,
+    XmlMatcher,
+)
+from changing_dot.dependency_graph.types import SupportedLanguages
 from changing_dot.utils.file_utils import get_file_extension
 from tree_sitter import Language, Parser
 from tree_sitter_xml import language_xml
-from typing_extensions import TypedDict
-
-SupportedLanguages = Literal["python", "c_sharp", "xml"]
-
-
-class NodeTypeToTerminal(TypedDict):
-    Import: list[str]
-    Class: list[str]
-    Method: list[str]
-    Field: list[str]
-
-
-c_sharp_node_type_to_terminal: NodeTypeToTerminal = {
-    "Class": ["class_declaration"],
-    "Method": ["method_declaration", "constructor_declaration"],
-    "Field": ["field_declaration", "property_declaration"],
-    "Import": ["using_directive"],
-}
-
-
-python_node_type_to_terminal: NodeTypeToTerminal = {
-    "Class": ["class_definition"],
-    "Method": ["function_definition"],
-    "Field": [],
-    "Import": ["import_statement"],
-}
-
-empty_node_type_to_terminal: NodeTypeToTerminal = {
-    "Class": [],
-    "Method": [],
-    "Field": [],
-    "Import": [],
-}
-
-xml_node_type_to_terminal: NodeTypeToTerminal = {
-    "Class": [],
-    "Method": ["element"],
-    "Field": [],
-    "Import": [],
-}
-
 
 extension_to_language: dict["str", SupportedLanguages] = {
     "py": "python",
@@ -70,21 +35,21 @@ def parser_from_file_path(file_path: str) -> Parser | None:
         return Parser(XML_LANGUAGE)
 
 
-def get_node_type_to_terminal_from_file_path(
+def get_matcher_from_file_path(
     file_path: str,
-) -> NodeTypeToTerminal:
+) -> ILanguageMatcher:
     language_or_none = extension_to_language.get(get_file_extension(file_path))
     if language_or_none is None:
-        return empty_node_type_to_terminal
-    return get_node_type_to_terminal_from_language(language_or_none)
+        return EmptyMatcher()
+    return get_matcher_from_language(language_or_none)
 
 
-def get_node_type_to_terminal_from_language(
+def get_matcher_from_language(
     language: SupportedLanguages,
-) -> NodeTypeToTerminal:
+) -> ILanguageMatcher:
     if language == "c_sharp":
-        return c_sharp_node_type_to_terminal
+        return CSharpMatcher()
     if language == "python":
-        return python_node_type_to_terminal
+        return PythonMatcher()
     if language == "xml":
-        return xml_node_type_to_terminal
+        return XmlMatcher()

--- a/back/src/changing_dot/dependency_graph/node_type_to_terminal.py
+++ b/back/src/changing_dot/dependency_graph/node_type_to_terminal.py
@@ -1,6 +1,7 @@
 import tree_sitter_c_sharp as tscsharp
 from changing_dot.dependency_graph.language_matchers import (
     CSharpMatcher,
+    CsProjMatcher,
     EmptyMatcher,
     ILanguageMatcher,
     PythonMatcher,
@@ -14,7 +15,7 @@ from tree_sitter_xml import language_xml
 extension_to_language: dict["str", SupportedLanguages] = {
     "py": "python",
     "cs": "c_sharp",
-    "csproj": "xml",
+    "csproj": "csproj",
     "xml": "xml",
 }
 
@@ -31,7 +32,7 @@ def parser_from_file_path(file_path: str) -> Parser | None:
         raise NotImplementedError("Python not implemented yet")
     if language == "c_sharp":
         return Parser(CS_LANGUAGE)
-    if language == "xml":
+    if language == "xml" or language == "csproj":
         return Parser(XML_LANGUAGE)
 
 
@@ -53,3 +54,5 @@ def get_matcher_from_language(
         return PythonMatcher()
     if language == "xml":
         return XmlMatcher()
+    if language == "csproj":
+        return CsProjMatcher()

--- a/back/src/changing_dot/dependency_graph/types.py
+++ b/back/src/changing_dot/dependency_graph/types.py
@@ -1,0 +1,28 @@
+from typing import Literal
+
+from pydantic import BaseModel
+from typing_extensions import TypedDict
+
+SupportedLanguages = Literal["python", "c_sharp", "xml"]
+
+
+class NodeTypeToTerminal(TypedDict):
+    Import: list[str]
+    Class: list[str]
+    Method: list[str]
+    Field: list[str]
+
+
+DependencyGraphNodeType = Literal["Import", "Class", "Method", "Field"]
+
+
+class DependencyGraphNode(BaseModel):
+    node_type: DependencyGraphNodeType
+    start_point: tuple[int, int]
+    end_point: tuple[int, int]
+    file_path: str
+    text: str
+
+
+class DependencyGraphNodeWithIndex(DependencyGraphNode):
+    index: int

--- a/back/src/changing_dot/dependency_graph/types.py
+++ b/back/src/changing_dot/dependency_graph/types.py
@@ -3,7 +3,7 @@ from typing import Literal
 from pydantic import BaseModel
 from typing_extensions import TypedDict
 
-SupportedLanguages = Literal["python", "c_sharp", "xml"]
+SupportedLanguages = Literal["python", "c_sharp", "xml", "csproj"]
 
 
 class NodeTypeToTerminal(TypedDict):

--- a/back/src/changing_dot/handle_node.py
+++ b/back/src/changing_dot/handle_node.py
@@ -157,8 +157,6 @@ def handle_problem_node(
 
     new_solution_index = G.add_solution_node(solution_node)
 
-    DG.update_graph_from_edits(solution_node["edits"])
-
     pending_problem_nodes = G.get_all_pending_problem_nodes()
     # updating all pending problem indexes
     # TODO or not, maybe change error

--- a/back/src/changing_dot/instruction_manager/block_instruction_manager/prompt.py
+++ b/back/src/changing_dot/instruction_manager/block_instruction_manager/prompt.py
@@ -12,6 +12,7 @@ Here are the possible blocks that you can use :
 {blocks}
 
 What is the easiest most straitforward way to fix this error.
+Please prefer "replace" changes rather than adds or removes
 Please add the line number to change in your response
 {failed_attempts}
 Please answer using the following format :

--- a/back/src/changing_dot/utils/file_utils.py
+++ b/back/src/changing_dot/utils/file_utils.py
@@ -28,5 +28,4 @@ def get_csharp_files(dir_to_explore: str) -> list[str]:
         if not any(pattern in file for pattern in exclude_patterns):
             filtered_files.append(os.path.abspath(file))
 
-    print("filtered files", filtered_files)
     return filtered_files

--- a/back/src/changing_dot/utils/file_utils.py
+++ b/back/src/changing_dot/utils/file_utils.py
@@ -14,6 +14,9 @@ def get_csharp_files(dir_to_explore: str) -> list[str]:
     dir_to_explore = os.path.dirname(dir_to_explore)
 
     csharp_files = glob.glob(os.path.join(dir_to_explore, "**", "*.cs"), recursive=True)
+    cs_proj_files = glob.glob(
+        os.path.join(dir_to_explore, "**", "*.csproj"), recursive=True
+    )
 
     exclude_patterns = [
         os.path.sep + "obj" + os.path.sep,
@@ -24,7 +27,7 @@ def get_csharp_files(dir_to_explore: str) -> list[str]:
     ]
 
     filtered_files = []
-    for file in csharp_files:
+    for file in csharp_files + cs_proj_files:
         if not any(pattern in file for pattern in exclude_patterns):
             filtered_files.append(os.path.abspath(file))
 

--- a/back/src/changing_dot/utils/process_diff.py
+++ b/back/src/changing_dot/utils/process_diff.py
@@ -38,8 +38,6 @@ def extract_hunks(diff: str) -> list[str]:
                 hunks.append(hunk)
             hunk = ""
 
-    print(hunks)
-
     return hunks
 
 

--- a/back/src/changing_dot/utils/text_functions.py
+++ b/back/src/changing_dot/utils/text_functions.py
@@ -2,7 +2,7 @@ import logging
 
 
 def read_text(filename: str) -> str:
-    encoding = "utf-8"
+    encoding = "utf-8-sig"
 
     try:
         with open(str(filename), encoding=encoding) as f:

--- a/back/tests/core/dependency_graph/fixtures/small.csproj
+++ b/back/tests/core/dependency_graph/fixtures/small.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net6.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+  </ItemGroup>
+
+</Project>

--- a/back/tests/core/dependency_graph/fixtures/updates/base.csproj
+++ b/back/tests/core/dependency_graph/fixtures/updates/base.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net6.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+  </ItemGroup>
+
+</Project>

--- a/back/tests/core/dependency_graph/fixtures/updates/empty_class.cs
+++ b/back/tests/core/dependency_graph/fixtures/updates/empty_class.cs
@@ -1,0 +1,3 @@
+class SimpleClass
+{
+}

--- a/back/tests/core/dependency_graph/fixtures/updates/subject.csproj
+++ b/back/tests/core/dependency_graph/fixtures/updates/subject.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net6.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+  </ItemGroup>
+
+</Project>

--- a/back/tests/core/dependency_graph/fixtures/updates/update.csproj
+++ b/back/tests/core/dependency_graph/fixtures/updates/update.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net6.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+    <PackageReference Include="Serilog" Version="3.0.1" />
+  </ItemGroup>
+
+</Project>

--- a/back/tests/core/dependency_graph/test_creation.py
+++ b/back/tests/core/dependency_graph/test_creation.py
@@ -2,6 +2,7 @@ import pytest
 from changing_dot.dependency_graph.dependency_graph import (
     DependencyGraph,
     DependencyGraphNode,
+    DependencyGraphNodeWithIndex,
 )
 
 
@@ -420,6 +421,147 @@ def test_xml_csproj_files() -> None:
     # for now each element is a method
     assert graph.get_number_of_nodes() == 38 + 16
     assert len(graph.get_parent_child_relationships()) == 37 + 15
+
+
+def test_csproj_files() -> None:
+    graph = DependencyGraph([get_fixture_path("small.csproj")])
+    # for now each element is a method
+    assert graph.get_number_of_nodes() == 6
+    assert graph.get_nodes_with_index() == [
+        DependencyGraphNodeWithIndex(
+            index=0,
+            node_type="Method",
+            file_path=get_fixture_path("small.csproj"),
+            start_point=(0, 0),
+            end_point=(11, 10),
+            text='<Project Sdk="Microsoft.NET.Sdk">\n\n  <PropertyGroup>\n    <OutputType>Exe</OutputType>\n    <TargetFramework>net6.0</TargetFramework>\n  </PropertyGroup>\n\n  <ItemGroup>\n    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />\n  </ItemGroup>\n\n</Project>',
+        ),
+        DependencyGraphNodeWithIndex(
+            index=1,
+            node_type="Method",
+            file_path=get_fixture_path("small.csproj"),
+            start_point=(2, 2),
+            end_point=(5, 18),
+            text="<PropertyGroup>\n    <OutputType>Exe</OutputType>\n    <TargetFramework>net6.0</TargetFramework>\n  </PropertyGroup>",
+        ),
+        DependencyGraphNodeWithIndex(
+            index=2,
+            node_type="Method",
+            file_path=get_fixture_path("small.csproj"),
+            start_point=(3, 4),
+            end_point=(3, 32),
+            text="<OutputType>Exe</OutputType>",
+        ),
+        DependencyGraphNodeWithIndex(
+            index=3,
+            node_type="Method",
+            file_path=get_fixture_path("small.csproj"),
+            start_point=(4, 4),
+            end_point=(4, 45),
+            text="<TargetFramework>net6.0</TargetFramework>",
+        ),
+        DependencyGraphNodeWithIndex(
+            index=4,
+            node_type="Method",
+            file_path=get_fixture_path("small.csproj"),
+            start_point=(7, 2),
+            end_point=(9, 14),
+            text='<ItemGroup>\n    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />\n  </ItemGroup>',
+        ),
+        DependencyGraphNodeWithIndex(
+            index=5,
+            node_type="Method",
+            file_path=get_fixture_path("small.csproj"),
+            start_point=(8, 4),
+            end_point=(8, 67),
+            text='<PackageReference Include="Newtonsoft.Json" Version="13.0.3" />',
+        ),
+    ]
+    assert len(graph.get_parent_child_relationships()) == 5
+
+    for relationship in [
+        (
+            DependencyGraphNode(
+                node_type="Method",
+                file_path=get_fixture_path("small.csproj"),
+                start_point=(0, 0),
+                end_point=(11, 10),
+                text='<Project Sdk="Microsoft.NET.Sdk">\n\n  <PropertyGroup>\n    <OutputType>Exe</OutputType>\n    <TargetFramework>net6.0</TargetFramework>\n  </PropertyGroup>\n\n  <ItemGroup>\n    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />\n  </ItemGroup>\n\n</Project>',
+            ),
+            DependencyGraphNode(
+                node_type="Method",
+                file_path=get_fixture_path("small.csproj"),
+                start_point=(2, 2),
+                end_point=(5, 18),
+                text="<PropertyGroup>\n    <OutputType>Exe</OutputType>\n    <TargetFramework>net6.0</TargetFramework>\n  </PropertyGroup>",
+            ),
+        ),
+        (
+            DependencyGraphNode(
+                node_type="Method",
+                file_path=get_fixture_path("small.csproj"),
+                start_point=(0, 0),
+                end_point=(11, 10),
+                text='<Project Sdk="Microsoft.NET.Sdk">\n\n  <PropertyGroup>\n    <OutputType>Exe</OutputType>\n    <TargetFramework>net6.0</TargetFramework>\n  </PropertyGroup>\n\n  <ItemGroup>\n    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />\n  </ItemGroup>\n\n</Project>',
+            ),
+            DependencyGraphNode(
+                node_type="Method",
+                file_path=get_fixture_path("small.csproj"),
+                start_point=(7, 2),
+                end_point=(9, 14),
+                text='<ItemGroup>\n    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />\n  </ItemGroup>',
+            ),
+        ),
+        (
+            DependencyGraphNode(
+                node_type="Method",
+                file_path=get_fixture_path("small.csproj"),
+                start_point=(2, 2),
+                end_point=(5, 18),
+                text="<PropertyGroup>\n    <OutputType>Exe</OutputType>\n    <TargetFramework>net6.0</TargetFramework>\n  </PropertyGroup>",
+            ),
+            DependencyGraphNode(
+                node_type="Method",
+                file_path=get_fixture_path("small.csproj"),
+                start_point=(3, 4),
+                end_point=(3, 32),
+                text="<OutputType>Exe</OutputType>",
+            ),
+        ),
+        (
+            DependencyGraphNode(
+                node_type="Method",
+                file_path=get_fixture_path("small.csproj"),
+                start_point=(2, 2),
+                end_point=(5, 18),
+                text="<PropertyGroup>\n    <OutputType>Exe</OutputType>\n    <TargetFramework>net6.0</TargetFramework>\n  </PropertyGroup>",
+            ),
+            DependencyGraphNode(
+                node_type="Method",
+                file_path=get_fixture_path("small.csproj"),
+                start_point=(4, 4),
+                end_point=(4, 45),
+                text="<TargetFramework>net6.0</TargetFramework>",
+            ),
+        ),
+        (
+            DependencyGraphNode(
+                node_type="Method",
+                file_path=get_fixture_path("small.csproj"),
+                start_point=(7, 2),
+                end_point=(9, 14),
+                text='<ItemGroup>\n    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />\n  </ItemGroup>',
+            ),
+            DependencyGraphNode(
+                node_type="Method",
+                file_path=get_fixture_path("small.csproj"),
+                start_point=(8, 4),
+                end_point=(8, 67),
+                text='<PackageReference Include="Newtonsoft.Json" Version="13.0.3" />',
+            ),
+        ),
+    ]:
+        assert relationship in graph.get_parent_child_relationships()
 
 
 def test_relations_in_multiple_files() -> None:

--- a/back/tests/core/dependency_graph/test_creation.py
+++ b/back/tests/core/dependency_graph/test_creation.py
@@ -421,14 +421,14 @@ def test_xml_csproj_files() -> None:
         [get_fixture_path("random.xml"), get_fixture_path("random.csproj")]
     )
     # for now each element is a method
-    assert graph.get_number_of_nodes() == 38 + 16
-    assert len(graph.get_parent_child_relationships()) == 37 + 15
+    assert graph.get_number_of_nodes() == 38 + 7
+    assert len(graph.get_parent_child_relationships()) == 37 + 6
 
 
 def test_csproj_files() -> None:
     graph = DependencyGraph([get_fixture_path("small.csproj")])
     # for now each element is a method
-    assert graph.get_number_of_nodes() == 6
+    assert graph.get_number_of_nodes() == 3
     assert graph.get_nodes_with_index() == [
         DependencyGraphNodeWithIndex(
             index=0,
@@ -450,36 +450,12 @@ def test_csproj_files() -> None:
             index=2,
             node_type="Method",
             file_path=get_fixture_path("small.csproj"),
-            start_point=(3, 4),
-            end_point=(3, 32),
-            text="<OutputType>Exe</OutputType>",
-        ),
-        DependencyGraphNodeWithIndex(
-            index=3,
-            node_type="Method",
-            file_path=get_fixture_path("small.csproj"),
-            start_point=(4, 4),
-            end_point=(4, 45),
-            text="<TargetFramework>net6.0</TargetFramework>",
-        ),
-        DependencyGraphNodeWithIndex(
-            index=4,
-            node_type="Method",
-            file_path=get_fixture_path("small.csproj"),
             start_point=(7, 2),
             end_point=(9, 14),
             text='<ItemGroup>\n    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />\n  </ItemGroup>',
         ),
-        DependencyGraphNodeWithIndex(
-            index=5,
-            node_type="Method",
-            file_path=get_fixture_path("small.csproj"),
-            start_point=(8, 4),
-            end_point=(8, 67),
-            text='<PackageReference Include="Newtonsoft.Json" Version="13.0.3" />',
-        ),
     ]
-    assert len(graph.get_parent_child_relationships()) == 5
+    assert len(graph.get_parent_child_relationships()) == 2
 
     for relationship in [
         (
@@ -512,54 +488,6 @@ def test_csproj_files() -> None:
                 start_point=(7, 2),
                 end_point=(9, 14),
                 text='<ItemGroup>\n    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />\n  </ItemGroup>',
-            ),
-        ),
-        (
-            DependencyGraphNode(
-                node_type="Method",
-                file_path=get_fixture_path("small.csproj"),
-                start_point=(2, 2),
-                end_point=(5, 18),
-                text="<PropertyGroup>\n    <OutputType>Exe</OutputType>\n    <TargetFramework>net6.0</TargetFramework>\n  </PropertyGroup>",
-            ),
-            DependencyGraphNode(
-                node_type="Method",
-                file_path=get_fixture_path("small.csproj"),
-                start_point=(3, 4),
-                end_point=(3, 32),
-                text="<OutputType>Exe</OutputType>",
-            ),
-        ),
-        (
-            DependencyGraphNode(
-                node_type="Method",
-                file_path=get_fixture_path("small.csproj"),
-                start_point=(2, 2),
-                end_point=(5, 18),
-                text="<PropertyGroup>\n    <OutputType>Exe</OutputType>\n    <TargetFramework>net6.0</TargetFramework>\n  </PropertyGroup>",
-            ),
-            DependencyGraphNode(
-                node_type="Method",
-                file_path=get_fixture_path("small.csproj"),
-                start_point=(4, 4),
-                end_point=(4, 45),
-                text="<TargetFramework>net6.0</TargetFramework>",
-            ),
-        ),
-        (
-            DependencyGraphNode(
-                node_type="Method",
-                file_path=get_fixture_path("small.csproj"),
-                start_point=(7, 2),
-                end_point=(9, 14),
-                text='<ItemGroup>\n    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />\n  </ItemGroup>',
-            ),
-            DependencyGraphNode(
-                node_type="Method",
-                file_path=get_fixture_path("small.csproj"),
-                start_point=(8, 4),
-                end_point=(8, 67),
-                text='<PackageReference Include="Newtonsoft.Json" Version="13.0.3" />',
             ),
         ),
     ]:

--- a/back/tests/core/dependency_graph/test_creation.py
+++ b/back/tests/core/dependency_graph/test_creation.py
@@ -1,6 +1,8 @@
 import pytest
 from changing_dot.dependency_graph.dependency_graph import (
     DependencyGraph,
+)
+from changing_dot.dependency_graph.types import (
     DependencyGraphNode,
     DependencyGraphNodeWithIndex,
 )

--- a/back/tests/core/dependency_graph/test_update.py
+++ b/back/tests/core/dependency_graph/test_update.py
@@ -25,11 +25,13 @@ def base() -> Generator[None, None, str]:
     base = get_fixture("base.cs")
     base2 = get_fixture("base_2.cs")
     base_full = get_fixture("base_full.cs")
+    base_csproj = get_fixture("base.csproj")
     yield
     write_text(get_fixture_path("subject_1.cs"), base)
     write_text(get_fixture_path("subject_2.cs"), base)
     write_text(get_fixture_path("subject_3.cs"), base2)
     write_text(get_fixture_path("subject_full.cs"), base_full)
+    write_text(get_fixture_path("subject.csproj"), base_csproj)
     return base
 
 
@@ -784,3 +786,87 @@ def test_block_id_in_wrong_file_raises_error() -> None:
                 ),
             ]
         )
+
+
+def test_handle_csproj_simple_update() -> None:
+    graph = DependencyGraph([get_fixture_path("subject.csproj")])
+
+    write_text(get_fixture_path("subject.csproj"), get_fixture("update.csproj"))
+
+    graph.update_graph_from_edits(
+        [
+            BlockEdit(
+                block_id=4,
+                file_path=get_fixture_path("subject.csproj"),
+                before="""<ItemGroup>
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+  </ItemGroup>""",
+                after="""<ItemGroup>
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+    <PackageReference Include="Serilog" Version="3.0.1" />
+  </ItemGroup>
+""",
+            )
+        ]
+    )
+
+    assert len(graph.get_node_by_type("Method")) == 7
+    assert (graph.get_nodes_with_index()) == [
+        DependencyGraphNodeWithIndex(
+            node_type="Method",
+            start_point=(0, 0),
+            end_point=(12, 10),
+            file_path="./tests/core/dependency_graph/fixtures/updates/subject.csproj",
+            text='<Project Sdk="Microsoft.NET.Sdk">\n\n  <PropertyGroup>\n    <OutputType>Exe</OutputType>\n    <TargetFramework>net6.0</TargetFramework>\n  </PropertyGroup>\n\n  <ItemGroup>\n    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />\n    <PackageReference Include="Serilog" Version="3.0.1" />\n  </ItemGroup>\n\n</Project>',
+            index=0,
+        ),
+        DependencyGraphNodeWithIndex(
+            node_type="Method",
+            start_point=(2, 2),
+            end_point=(5, 18),
+            file_path="./tests/core/dependency_graph/fixtures/updates/subject.csproj",
+            text="<PropertyGroup>\n    <OutputType>Exe</OutputType>\n    <TargetFramework>net6.0</TargetFramework>\n  </PropertyGroup>",
+            index=1,
+        ),
+        DependencyGraphNodeWithIndex(
+            node_type="Method",
+            start_point=(3, 4),
+            end_point=(3, 32),
+            file_path="./tests/core/dependency_graph/fixtures/updates/subject.csproj",
+            text="<OutputType>Exe</OutputType>",
+            index=2,
+        ),
+        DependencyGraphNodeWithIndex(
+            node_type="Method",
+            start_point=(4, 4),
+            end_point=(4, 45),
+            file_path="./tests/core/dependency_graph/fixtures/updates/subject.csproj",
+            text="<TargetFramework>net6.0</TargetFramework>",
+            index=3,
+        ),
+        DependencyGraphNodeWithIndex(
+            node_type="Method",
+            start_point=(7, 2),
+            end_point=(10, 14),
+            file_path="./tests/core/dependency_graph/fixtures/updates/subject.csproj",
+            text='<ItemGroup>\n    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />\n    <PackageReference Include="Serilog" Version="3.0.1" />\n  </ItemGroup>',
+            index=4,
+        ),
+        # Index 5 is removed
+        DependencyGraphNodeWithIndex(
+            node_type="Method",
+            start_point=(8, 4),
+            end_point=(8, 67),
+            file_path="./tests/core/dependency_graph/fixtures/updates/subject.csproj",
+            text='<PackageReference Include="Newtonsoft.Json" Version="13.0.3" />',
+            index=6,
+        ),
+        DependencyGraphNodeWithIndex(
+            node_type="Method",
+            start_point=(9, 4),
+            end_point=(9, 58),
+            file_path="./tests/core/dependency_graph/fixtures/updates/subject.csproj",
+            text='<PackageReference Include="Serilog" Version="3.0.1" />',
+            index=7,
+        ),
+    ]

--- a/back/tests/core/dependency_graph/test_update.py
+++ b/back/tests/core/dependency_graph/test_update.py
@@ -184,34 +184,39 @@ def test_update_with_no_graph_impact() -> None:
         ]
     )
 
-    assert graph.get_number_of_nodes() == 2
+
+def test_update_that_removes_block() -> None:
+    graph = DependencyGraph([get_fixture_path("subject_1.cs")])
+
+    write_text(get_fixture_path("subject_1.cs"), get_fixture("empty_class.cs"))
+
+    graph.update_graph_from_edits(
+        [
+            BlockEdit(
+                block_id=1,
+                file_path=get_fixture_path("subject_1.cs"),
+                before="""static string SimpleMethod()
+    {
+        return "Hello, World!";
+    }""",
+                after="",
+            )
+        ]
+    )
+
+    assert graph.get_number_of_nodes() == 1
     assert graph.get_node_by_type("Class") == [
         DependencyGraphNode(
             node_type="Class",
             start_point=(0, 0),
-            end_point=(6, 1),
+            end_point=(2, 1),
             file_path=get_fixture_path("subject_1.cs"),
             text="""class SimpleClass
 {
-    static string SimpleMethod()
-    {
-        return "Updated Hello, World!";
-    }
 }""",
         ),
     ]
-    assert (graph.get_node_by_type("Method")) == [
-        DependencyGraphNode(
-            node_type="Method",
-            start_point=(2, 4),
-            end_point=(5, 5),
-            file_path=get_fixture_path("subject_1.cs"),
-            text="""static string SimpleMethod()
-    {
-        return "Updated Hello, World!";
-    }""",
-        )
-    ]
+    assert (graph.get_node_by_type("Method")) == []
 
 
 def test_update_graph_that_shifts_indexes_related_blocks() -> None:

--- a/back/tests/core/dependency_graph/test_update.py
+++ b/back/tests/core/dependency_graph/test_update.py
@@ -826,7 +826,7 @@ def test_handle_csproj_simple_update() -> None:
     graph.update_graph_from_edits(
         [
             BlockEdit(
-                block_id=4,
+                block_id=2,
                 file_path=get_fixture_path("subject.csproj"),
                 before="""<ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
@@ -840,7 +840,7 @@ def test_handle_csproj_simple_update() -> None:
         ]
     )
 
-    assert len(graph.get_node_by_type("Method")) == 7
+    assert len(graph.get_node_by_type("Method")) == 3
     assert (graph.get_nodes_with_index()) == [
         DependencyGraphNodeWithIndex(
             node_type="Method",
@@ -860,43 +860,10 @@ def test_handle_csproj_simple_update() -> None:
         ),
         DependencyGraphNodeWithIndex(
             node_type="Method",
-            start_point=(3, 4),
-            end_point=(3, 32),
-            file_path="./tests/core/dependency_graph/fixtures/updates/subject.csproj",
-            text="<OutputType>Exe</OutputType>",
-            index=2,
-        ),
-        DependencyGraphNodeWithIndex(
-            node_type="Method",
-            start_point=(4, 4),
-            end_point=(4, 45),
-            file_path="./tests/core/dependency_graph/fixtures/updates/subject.csproj",
-            text="<TargetFramework>net6.0</TargetFramework>",
-            index=3,
-        ),
-        DependencyGraphNodeWithIndex(
-            node_type="Method",
             start_point=(7, 2),
             end_point=(10, 14),
             file_path="./tests/core/dependency_graph/fixtures/updates/subject.csproj",
             text='<ItemGroup>\n    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />\n    <PackageReference Include="Serilog" Version="3.0.1" />\n  </ItemGroup>',
-            index=4,
-        ),
-        # Index 5 is removed
-        DependencyGraphNodeWithIndex(
-            node_type="Method",
-            start_point=(8, 4),
-            end_point=(8, 67),
-            file_path="./tests/core/dependency_graph/fixtures/updates/subject.csproj",
-            text='<PackageReference Include="Newtonsoft.Json" Version="13.0.3" />',
-            index=6,
-        ),
-        DependencyGraphNodeWithIndex(
-            node_type="Method",
-            start_point=(9, 4),
-            end_point=(9, 58),
-            file_path="./tests/core/dependency_graph/fixtures/updates/subject.csproj",
-            text='<PackageReference Include="Serilog" Version="3.0.1" />',
-            index=7,
+            index=2,
         ),
     ]

--- a/back/tests/core/dependency_graph/test_update.py
+++ b/back/tests/core/dependency_graph/test_update.py
@@ -788,6 +788,29 @@ def test_block_id_in_wrong_file_raises_error() -> None:
         )
 
 
+def test_wrong_block_id_for_changes_raises_Error() -> None:
+    graph = DependencyGraph([get_fixture_path("subject_1.cs")])
+
+    write_text(get_fixture_path("subject_1.cs"), get_fixture("update_1.cs"))
+
+    with pytest.raises(
+        AssertionError, match="The before does not match the text in block"
+    ):
+        graph.update_graph_from_edits(
+            [
+                BlockEdit(
+                    file_path=get_fixture_path("subject_1.cs"),
+                    block_id=1,
+                    before="some random text",
+                    after="""static string SimpleMethod()
+    {
+        return "Updated Hello, World!";
+    }""",
+                ),
+            ]
+        )
+
+
 def test_handle_csproj_simple_update() -> None:
     graph = DependencyGraph([get_fixture_path("subject.csproj")])
 

--- a/back/tests/core/dependency_graph/test_update.py
+++ b/back/tests/core/dependency_graph/test_update.py
@@ -4,6 +4,8 @@ import pytest
 from changing_dot.custom_types import BlockEdit
 from changing_dot.dependency_graph.dependency_graph import (
     DependencyGraph,
+)
+from changing_dot.dependency_graph.types import (
     DependencyGraphNode,
     DependencyGraphNodeWithIndex,
 )

--- a/back/tests/core/test_commit.py
+++ b/back/tests/core/test_commit.py
@@ -228,7 +228,7 @@ def test_handling_empty_commits(repo: Repo, file_modifier: IModifyle) -> None:
                 block_id=2,
                 before="""    static string SimpleMethod()
     {
-        return "Hello, World!";
+        return "Welcome, World!";
     }
 """,
                 after="""    static string SimpleMethod()

--- a/back/tests/core/test_e2e.py
+++ b/back/tests/core/test_e2e.py
@@ -52,9 +52,9 @@ def test_e2e() -> None:
     project_name = "test"
     is_local = True
     initial_change = InitialChange(
-        error="Change DistincId to NewVariableName",
+        error="DistincId does not exist",
         file_path="./tests/core/fixtures/e2e/base.cs",
-        error_position=(11, 0, 11, 0),
+        error_position=(17, 0, 17, 0),
     )
     restriction_options = RestrictionOptions(
         project_blacklist=None,
@@ -73,14 +73,6 @@ def test_e2e() -> None:
                     "pos": (17, 0, 17, 0),
                 }
             ],  # does solution fix error -> No
-            [
-                {
-                    "text": "DistincId does not exist",
-                    "file_path": "./tests/core/fixtures/e2e/base.cs",
-                    "project_name": "test",
-                    "pos": (17, 0, 17, 0),
-                }
-            ],  # create problem nodes
             [],  # does solution fix error -> Yes
         ]
     )
@@ -147,16 +139,16 @@ def test_e2e() -> None:
         if os.path.isfile(os.path.join(expected_directory_path, f))
     ]
 
-    assert len(files) == 2
+    assert len(files) == 1
 
-    expected_file_path = "./outputs/tmp/1_test.pickle"
+    expected_file_path = "./outputs/tmp/0_test.pickle"
 
     with open(expected_file_path, "rb") as pickle_file:
         data = pickle.load(pickle_file)
         data_graph = ChangingGraph(data)
         assert (
-            data_graph.get_number_of_nodes() == 4
-        )  # 1 initial -> 1 solution -> 1 problem -> 1 solution
+            data_graph.get_number_of_nodes() == 3
+        )  # 1 initial -> 1 solution failed -> 1 solution ok
 
     ### Optimize Graph
 
@@ -172,15 +164,15 @@ def test_e2e() -> None:
         if os.path.isfile(os.path.join(expected_directory_path, f))
     ]
 
-    assert len(files) == 3  # add a new optimize step
+    assert len(files) == 2  # add a new optimize step
 
-    expected_file_path = "./outputs/tmp/2_test.pickle"
+    expected_file_path = "./outputs/tmp/1_test.pickle"
 
     with open(expected_file_path, "rb") as pickle_file:
         data = pickle.load(pickle_file)
         data_graph = ChangingGraph(data)
         assert (
-            data_graph.get_number_of_nodes() == 4
+            data_graph.get_number_of_nodes() == 3
         )  # Same as before since nothing is optimized
 
     # ### Resume graph
@@ -193,7 +185,7 @@ def test_e2e() -> None:
     )
 
     resume_initial_node = ResumeInitialNode(
-        index=2,
+        index=0,
         status="handled",
         error={
             "text": "DistincId does not exist",
@@ -233,11 +225,11 @@ def test_e2e() -> None:
         if os.path.isfile(os.path.join(expected_directory_path, f))
     ]
 
-    assert len(files) == 4  # add a new step
+    assert len(files) == 3  # add a new step
 
-    expected_file_path = "./outputs/tmp/3_test.pickle"
+    expected_file_path = "./outputs/tmp/2_test.pickle"
 
     with open(expected_file_path, "rb") as pickle_file:
         data = pickle.load(pickle_file)
         data_graph = ChangingGraph(data)
-        assert data_graph.get_number_of_nodes() == 5  # Add a new solution
+        assert data_graph.get_number_of_nodes() == 4  # Add a new solution


### PR DESCRIPTION
The goal of this PR is to better handle csproj files :
- When reading a C# project, we also read the proj files
- Be able to parse and understand the file -> we use the Method node type at the moment for a XML/ CSproj element
- Do not take into account the "leaf" elements since this causes reliability issues in practice
- Refactor the way we match AST nodes and DG nodes to be able to take into account more constraints like the one above
- Fix an issue reading utf8-BOM encoded files
- Add a couple tests for these features