### PR TITLE
Feature: added llm_provider param to config file

### DIFF
--- a/back/src/changing_dot/commit/conflict_handler.py
+++ b/back/src/changing_dot/commit/conflict_handler.py
@@ -1,6 +1,6 @@
-import os
 import re
 
+from changing_dot.utils.llm_model_utils import get_mistral_api_key
 from changing_dot_visualize.observer import Observer
 from dotenv import load_dotenv
 from langchain_core.language_models.chat_models import BaseChatModel
@@ -8,7 +8,6 @@ from langchain_core.output_parsers import StrOutputParser
 from langchain_core.prompts import ChatPromptTemplate
 from langchain_mistralai import ChatMistralAI
 from langchain_openai import ChatOpenAI
-from pydantic.v1.types import SecretStr
 
 
 def extract_code_blocks(text: str) -> str:
@@ -73,6 +72,6 @@ def create_openai_conflict_handler() -> ConflictHandler:
 
 def create_mistral_conflict_handler() -> ConflictHandler:
     load_dotenv()
-    mistral_api_key = SecretStr(os.getenv("MISTRAL_API_KEY") or "")
+    mistral_api_key = get_mistral_api_key()
     chat = ChatMistralAI(mistral_api_key=mistral_api_key, model="mistral-large-latest")
     return ConflictHandler(model=chat)

--- a/back/src/changing_dot/create_graph.py
+++ b/back/src/changing_dot/create_graph.py
@@ -12,7 +12,7 @@ from changing_dot.error_manager.error_manager import (
 )
 from changing_dot.handle_node import handle_node
 from changing_dot.instruction_interpreter.block_instruction_interpreter import (
-    create_interpreter,
+    create_instruction_interpreter,
 )
 from changing_dot.instruction_interpreter.instruction_interpreter import (
     IBlockInstructionInterpreter,
@@ -64,7 +64,7 @@ def run_create_graph(
         is_local=is_local,
     )
 
-    interpreter = create_interpreter(observer, llm_provider)
+    interpreter = create_instruction_interpreter(observer, llm_provider)
 
     initialisation: ErrorInitialization = {
         "init_type": "error",

--- a/back/src/changing_dot/create_graph.py
+++ b/back/src/changing_dot/create_graph.py
@@ -1,5 +1,5 @@
 import uuid
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Literal
 
 from changing_dot_visualize.observer import Observer
 
@@ -12,14 +12,14 @@ from changing_dot.error_manager.error_manager import (
 )
 from changing_dot.handle_node import handle_node
 from changing_dot.instruction_interpreter.block_instruction_interpreter import (
-    create_openai_interpreter,
+    create_interpreter,
 )
 from changing_dot.instruction_interpreter.instruction_interpreter import (
     IBlockInstructionInterpreter,
 )
 from changing_dot.instruction_manager.block_instruction_manager.block_instruction_manager import (
     IInstructionManagerBlock,
-    create_openai_instruction_manager,
+    create_instruction_manager,
 )
 from changing_dot.modifyle.modifyle import IModifyle, IntegralModifyle
 from changing_dot.utils.file_utils import get_csharp_files
@@ -39,11 +39,13 @@ def run_create_graph(
     restriction_options: RestrictionOptions,
     initial_change: InitialChange,
     is_local: bool,
+    llm_provider: Literal["OPENAI", "MISTRAL"],
 ) -> None:
     job_id = str(uuid.uuid4())
 
-    instruction_manager: BlockInstructionManager = create_openai_instruction_manager(
-        goal
+    # TODO rajouter llm provider in parent
+    instruction_manager: BlockInstructionManager = create_instruction_manager(
+        goal, llm_provider
     )
 
     error_manager = RoslynErrorManager(solution_path, restriction_options)
@@ -62,7 +64,7 @@ def run_create_graph(
         is_local=is_local,
     )
 
-    interpreter = create_openai_interpreter(observer)
+    interpreter = create_interpreter(observer, llm_provider)
 
     initialisation: ErrorInitialization = {
         "init_type": "error",

--- a/back/src/changing_dot/custom_types.py
+++ b/back/src/changing_dot/custom_types.py
@@ -193,6 +193,7 @@ class CreateGraphInput(BaseModel):
     )
     initial_change: InitialChange
     is_local: bool
+    llm_provider: Literal["OPENAI", "MISTRAL"]
 
     @field_validator("solution_path")
     def validate_path(cls, value: str) -> str:
@@ -258,6 +259,7 @@ class ResumeGraphInput(BaseModel):
     )
     resume_initial_node: ResumeInitialNode
     is_local: bool
+    llm_provider: Literal["OPENAI", "MISTRAL"]
 
     @field_validator("solution_path", "base_path")
     def validate_path(cls, value: str) -> str:

--- a/back/src/changing_dot/instruction_interpreter/block_instruction_interpreter.py
+++ b/back/src/changing_dot/instruction_interpreter/block_instruction_interpreter.py
@@ -81,7 +81,7 @@ class BlockInstructionInterpreter(IBlockInstructionInterpreter):
         )
 
 
-def create_interpreter(
+def create_instruction_interpreter(
     observer: Observer,
     llm_provider: Literal["OPENAI", "MISTRAL"],
 ) -> BlockInstructionInterpreter:

--- a/back/src/changing_dot/instruction_interpreter/block_instruction_interpreter.py
+++ b/back/src/changing_dot/instruction_interpreter/block_instruction_interpreter.py
@@ -86,14 +86,14 @@ def create_interpreter(
     llm_provider: Literal["OPENAI", "MISTRAL"],
 ) -> BlockInstructionInterpreter:
     load_dotenv()
-    chat: BaseChatModel | None = None
     if llm_provider == "OPENAI":
-        chat = ChatOpenAI(model="gpt-4o", temperature=0.0)
+        openai_chat: BaseChatModel = ChatOpenAI(model="gpt-4o", temperature=0.0)
+        return BlockInstructionInterpreter(model=openai_chat, observer=observer)
     elif llm_provider == "MISTRAL":
         mistral_api_key = get_mistral_api_key()
-        chat = ChatMistralAI(
+        mistral_chat: BaseChatModel = ChatMistralAI(
             mistral_api_key=mistral_api_key,
             model="mistral-large-latest",
             temperature=0.0,
         )
-    return BlockInstructionInterpreter(model=chat, observer=observer)
+        return BlockInstructionInterpreter(model=mistral_chat, observer=observer)

--- a/back/src/changing_dot/instruction_manager/block_instruction_manager/block_instruction_manager.py
+++ b/back/src/changing_dot/instruction_manager/block_instruction_manager/block_instruction_manager.py
@@ -1,3 +1,5 @@
+from typing import Literal
+
 from changing_dot.changing_graph.changing_graph import ChangingGraph
 from changing_dot.custom_types import InstructionBlock
 from changing_dot.dependency_graph.dependency_graph import DependencyGraph
@@ -5,6 +7,7 @@ from changing_dot.instruction_manager.block_instruction_manager.prompt import (
     prompt,
     system_prompt,
 )
+from changing_dot.utils.llm_model_utils import get_mistral_api_key
 from dotenv import load_dotenv
 from langchain_core.language_models.chat_models import BaseChatModel
 from langchain_core.output_parsers import (
@@ -14,6 +17,7 @@ from langchain_core.prompts import ChatPromptTemplate
 from langchain_core.runnables import (
     RunnableSerializable,
 )
+from langchain_mistralai import ChatMistralAI
 from langchain_openai import ChatOpenAI
 from pydantic import BaseModel, ValidationError
 
@@ -150,7 +154,18 @@ class BlockInstructionManager(IInstructionManagerBlock):
         return instruction_chain
 
 
-def create_openai_instruction_manager(goal: str) -> BlockInstructionManager:
+def create_instruction_manager(
+    goal: str, llm_provider: Literal["OPENAI", "MISTRAL"]
+) -> BlockInstructionManager:
     load_dotenv()
-    chat = ChatOpenAI(model="gpt-4o", temperature=0.0)
+    chat: BaseChatModel | None = None
+    if llm_provider == "OPENAI":
+        chat = ChatOpenAI(model="gpt-4o", temperature=0.0)
+    elif llm_provider == "MISTRAL":
+        mistral_api_key = get_mistral_api_key()
+        chat = ChatMistralAI(
+            mistral_api_key=mistral_api_key,
+            model="mistral-large-latest",
+            temperature=0.0,
+        )
     return BlockInstructionManager(model=chat, goal=goal)

--- a/back/src/changing_dot/instruction_manager/block_instruction_manager/block_instruction_manager.py
+++ b/back/src/changing_dot/instruction_manager/block_instruction_manager/block_instruction_manager.py
@@ -158,14 +158,14 @@ def create_instruction_manager(
     goal: str, llm_provider: Literal["OPENAI", "MISTRAL"]
 ) -> BlockInstructionManager:
     load_dotenv()
-    chat: BaseChatModel | None = None
     if llm_provider == "OPENAI":
-        chat = ChatOpenAI(model="gpt-4o", temperature=0.0)
+        openai_chat: BaseChatModel = ChatOpenAI(model="gpt-4o", temperature=0.0)
+        return BlockInstructionManager(model=openai_chat, goal=goal)
     elif llm_provider == "MISTRAL":
         mistral_api_key = get_mistral_api_key()
-        chat = ChatMistralAI(
+        mistral_chat: BaseChatModel = ChatMistralAI(
             mistral_api_key=mistral_api_key,
             model="mistral-large-latest",
             temperature=0.0,
         )
-    return BlockInstructionManager(model=chat, goal=goal)
+        return BlockInstructionManager(model=mistral_chat, goal=goal)

--- a/back/src/changing_dot/resume_graph.py
+++ b/back/src/changing_dot/resume_graph.py
@@ -1,5 +1,5 @@
 import uuid
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Literal
 
 from changing_dot_visualize.observer import Observer
 
@@ -12,10 +12,10 @@ from changing_dot.error_manager.error_manager import (
 )
 from changing_dot.handle_node import resume_problem_node
 from changing_dot.instruction_interpreter.block_instruction_interpreter import (
-    create_openai_interpreter,
+    create_interpreter,
 )
 from changing_dot.instruction_manager.block_instruction_manager.block_instruction_manager import (
-    create_openai_instruction_manager,
+    create_instruction_manager,
 )
 from changing_dot.modifyle.modifyle import IntegralModifyle
 from changing_dot.utils.file_utils import get_csharp_files
@@ -35,13 +35,14 @@ def run_resume_graph(
     commit: Commit,
     restriction_options: RestrictionOptions,
     resume_initial_node: ResumeInitialNode,
+    llm_provider: Literal["OPENAI", "MISTRAL"],
     is_local: bool = True,
 ) -> None:
     set_repo(commit)
 
     job_id = str(uuid.uuid4())
 
-    instruction_manager = create_openai_instruction_manager(goal)
+    instruction_manager = create_instruction_manager(goal, llm_provider)
 
     graphs = process_pickle_files(f"{base_path}/{iteration_name}/", is_local)
 
@@ -62,7 +63,7 @@ def run_resume_graph(
         step=len(graphs),
     )
 
-    interpreter = create_openai_interpreter(observer)
+    interpreter = create_interpreter(observer, llm_provider)
 
     node: ProblemNode = {
         "index": resume_initial_node.index,

--- a/back/src/changing_dot/resume_graph.py
+++ b/back/src/changing_dot/resume_graph.py
@@ -12,7 +12,7 @@ from changing_dot.error_manager.error_manager import (
 )
 from changing_dot.handle_node import resume_problem_node
 from changing_dot.instruction_interpreter.block_instruction_interpreter import (
-    create_interpreter,
+    create_instruction_interpreter,
 )
 from changing_dot.instruction_manager.block_instruction_manager.block_instruction_manager import (
     create_instruction_manager,
@@ -63,7 +63,7 @@ def run_resume_graph(
         step=len(graphs),
     )
 
-    interpreter = create_interpreter(observer, llm_provider)
+    interpreter = create_instruction_interpreter(observer, llm_provider)
 
     node: ProblemNode = {
         "index": resume_initial_node.index,

--- a/back/src/changing_dot/utils/llm_model_utils.py
+++ b/back/src/changing_dot/utils/llm_model_utils.py
@@ -1,0 +1,7 @@
+import os
+
+from pydantic.v1.types import SecretStr
+
+
+def get_mistral_api_key() -> SecretStr:
+    return SecretStr(os.getenv("MISTRAL_API_KEY") or "")

--- a/back/src/changing_dot_cli/cli.py
+++ b/back/src/changing_dot_cli/cli.py
@@ -76,6 +76,7 @@ def create(config: str, local: bool, dev: bool) -> None:
             create_graph_input.restriction_options,
             create_graph_input.initial_change,
             create_graph_input.is_local,
+            create_graph_input.llm_provider,
         )
         return
 
@@ -88,6 +89,7 @@ def create(config: str, local: bool, dev: bool) -> None:
             create_graph_input.restriction_options,
             create_graph_input.initial_change,
             create_graph_input.is_local,
+            create_graph_input.llm_provider,
         )
 
 
@@ -175,6 +177,7 @@ def resume(config: str, local: bool, resume_node: str, dev: bool) -> None:
             resume_graph_input.restriction_options,
             resume_graph_input.resume_initial_node,
             resume_graph_input.is_local,
+            resume_graph_input.llm_provider,
         )
         return
 
@@ -189,6 +192,7 @@ def resume(config: str, local: bool, resume_node: str, dev: bool) -> None:
             resume_graph_input.restriction_options,
             resume_graph_input.resume_initial_node,
             resume_graph_input.is_local,
+            resume_graph_input.llm_provider,
         )
 
 

--- a/back/src/changing_dot_cli/cli.py
+++ b/back/src/changing_dot_cli/cli.py
@@ -176,8 +176,8 @@ def resume(config: str, local: bool, resume_node: str, dev: bool) -> None:
             resume_graph_input.commit,
             resume_graph_input.restriction_options,
             resume_graph_input.resume_initial_node,
-            resume_graph_input.is_local,
             resume_graph_input.llm_provider,
+            resume_graph_input.is_local,
         )
         return
 
@@ -191,8 +191,8 @@ def resume(config: str, local: bool, resume_node: str, dev: bool) -> None:
             resume_graph_input.commit,
             resume_graph_input.restriction_options,
             resume_graph_input.resume_initial_node,
-            resume_graph_input.is_local,
             resume_graph_input.llm_provider,
+            resume_graph_input.is_local,
         )
 
 

--- a/back/src/scripts/benchmark_job.py
+++ b/back/src/scripts/benchmark_job.py
@@ -20,7 +20,7 @@ from changing_dot.error_manager.error_manager import (
     RoslynErrorManager,
 )
 from changing_dot.instruction_interpreter.block_instruction_interpreter import (
-    create_interpreter,
+    create_instruction_interpreter,
 )
 from changing_dot.instruction_manager.block_instruction_manager.block_instruction_manager import (
     create_instruction_manager,
@@ -83,7 +83,7 @@ def benchmark_job(
 
             observer = Observer(G, analytics.run.name, benchmark_item, job_id)
 
-            interpreter: IBlockInstructionInterpreter = create_interpreter(
+            interpreter: IBlockInstructionInterpreter = create_instruction_interpreter(
                 observer, llm_provider
             )
 

--- a/back/src/scripts/benchmark_job.py
+++ b/back/src/scripts/benchmark_job.py
@@ -1,5 +1,5 @@
 import uuid
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Literal
 
 from analytics.wandb_analytics import WandbAnalytics
 from changing_dot.changing_graph.changing_graph import ChangingGraph
@@ -20,10 +20,10 @@ from changing_dot.error_manager.error_manager import (
     RoslynErrorManager,
 )
 from changing_dot.instruction_interpreter.block_instruction_interpreter import (
-    create_openai_interpreter,
+    create_interpreter,
 )
 from changing_dot.instruction_manager.block_instruction_manager.block_instruction_manager import (
-    create_openai_instruction_manager,
+    create_instruction_manager,
 )
 from changing_dot.modifyle.modifyle import IModifyle, IntegralModifyle
 from changing_dot.optimize_graph import optimize_graph
@@ -46,6 +46,7 @@ def benchmark_job(
     goal: str,
     initial_change: InitialChange,
     commit: Commit,
+    llm_provider: Literal["OPENAI", "MISTRAL"],
     restriction_options: RestrictionOptions | None = None,
 ) -> None:
     analytics = WandbAnalytics()
@@ -62,7 +63,7 @@ def benchmark_job(
         )
     )
 
-    instruction_manager = create_openai_instruction_manager(goal)
+    instruction_manager = create_instruction_manager(goal, llm_provider)
 
     error_manager = RoslynErrorManager(solution_path, restriction_options)
 
@@ -82,8 +83,8 @@ def benchmark_job(
 
             observer = Observer(G, analytics.run.name, benchmark_item, job_id)
 
-            interpreter: IBlockInstructionInterpreter = create_openai_interpreter(
-                observer
+            interpreter: IBlockInstructionInterpreter = create_interpreter(
+                observer, llm_provider
             )
 
             initialisation: ErrorInitialization = {

--- a/back/src/scripts/run_benchmark.py
+++ b/back/src/scripts/run_benchmark.py
@@ -16,7 +16,7 @@ from changing_dot.error_manager.error_manager import (
     RoslynErrorManager,
 )
 from changing_dot.instruction_interpreter.block_instruction_interpreter import (
-    create_interpreter,
+    create_instruction_interpreter,
 )
 from changing_dot.instruction_interpreter.instruction_interpreter import (
     IBlockInstructionInterpreter,
@@ -72,7 +72,7 @@ if __name__ == "__main__":
 
             observer = Observer(G, analytics.run.name, benchmark_item, job_id)
 
-            interpreter: IBlockInstructionInterpreter = create_interpreter(
+            interpreter: IBlockInstructionInterpreter = create_instruction_interpreter(
                 observer, config["llm_provider"]
             )
 

--- a/back/src/scripts/run_benchmark.py
+++ b/back/src/scripts/run_benchmark.py
@@ -16,13 +16,13 @@ from changing_dot.error_manager.error_manager import (
     RoslynErrorManager,
 )
 from changing_dot.instruction_interpreter.block_instruction_interpreter import (
-    create_openai_interpreter,
+    create_interpreter,
 )
 from changing_dot.instruction_interpreter.instruction_interpreter import (
     IBlockInstructionInterpreter,
 )
 from changing_dot.instruction_manager.block_instruction_manager.block_instruction_manager import (
-    create_openai_instruction_manager,
+    create_instruction_manager,
 )
 from changing_dot.modifyle.modifyle import IModifyle, IntegralModifyle
 from changing_dot.optimize_graph import optimize_graph
@@ -47,7 +47,9 @@ if __name__ == "__main__":
         with analytics.benchmark_item(benchmark_item) as current_benchmark_result:
             job_id = str(uuid.uuid4())
 
-            instruction_manager = create_openai_instruction_manager(config["goal"])
+            instruction_manager = create_instruction_manager(
+                config["goal"], config["llm_provider"]
+            )
 
             restriction_options = config.get(
                 "restriction_options",
@@ -70,8 +72,8 @@ if __name__ == "__main__":
 
             observer = Observer(G, analytics.run.name, benchmark_item, job_id)
 
-            interpreter: IBlockInstructionInterpreter = create_openai_interpreter(
-                observer
+            interpreter: IBlockInstructionInterpreter = create_interpreter(
+                observer, config["llm_provider"]
             )
 
             initialisation: ErrorInitialization = {

--- a/back/src/scripts/test/test_instructions.py
+++ b/back/src/scripts/test/test_instructions.py
@@ -55,7 +55,7 @@ G.add_solution_node(failed_solution)
 G.add_edge(0, 1)
 
 instruction_manager = create_instruction_manager(
-    "Remove Newtonsoft dependency to then change it to with System.Text.Json"
+    "Remove Newtonsoft dependency to then change it to with System.Text.Json", "MISTRAL"
 )
 
 DG = DependencyGraph(["file"])

--- a/back/src/scripts/test/test_instructions.py
+++ b/back/src/scripts/test/test_instructions.py
@@ -3,7 +3,7 @@ import json
 from changing_dot.changing_graph.changing_graph import ChangingGraph
 from changing_dot.dependency_graph.dependency_graph import DependencyGraph
 from changing_dot.instruction_manager.block_instruction_manager.block_instruction_manager import (
-    create_openai_instruction_manager,
+    create_instruction_manager,
 )
 from loguru import logger
 
@@ -54,7 +54,7 @@ G.add_problem_node(initial_problem)
 G.add_solution_node(failed_solution)
 G.add_edge(0, 1)
 
-instruction_manager = create_openai_instruction_manager(
+instruction_manager = create_instruction_manager(
     "Remove Newtonsoft dependency to then change it to with System.Text.Json"
 )
 

--- a/examples/example.yaml
+++ b/examples/example.yaml
@@ -15,3 +15,5 @@ initial_change:
 commit:
   branch_name: changing_branch
   git_path: ./ChangingLevels/
+
+llm_provider: MISTRAL


### PR DESCRIPTION
Users can now input in the .yaml config file a "llm_provider" param that takes either MISTRAL or OPENAI as argument, to use the selected provider for normal inference

