### PR TITLE
feat!: merge optimize graph step to create graph

### DIFF
--- a/back/src/changing_dot/create_graph.py
+++ b/back/src/changing_dot/create_graph.py
@@ -32,6 +32,7 @@ from changing_dot.instruction_manager.block_instruction_manager.block_instructio
     create_instruction_manager,
 )
 from changing_dot.modifyle.modifyle import IModifyle, IntegralModifyle
+from changing_dot.optimize_graph import optimize_graph
 
 if TYPE_CHECKING:
     from changing_dot.instruction_manager.block_instruction_manager.block_instruction_manager import (
@@ -161,5 +162,7 @@ def create_graph(
         pending_nodes = G.get_all_pending_nodes()
 
     file_modifier.revert_changes(DG)
+
+    optimize_graph(G, observer)
 
     observer.log("Finished")

--- a/back/src/changing_dot/custom_types.py
+++ b/back/src/changing_dot/custom_types.py
@@ -179,17 +179,6 @@ class CommitGraphInput(BaseModel):
         return validate_and_convert_path(value)
 
 
-class OptimizeGraphInput(BaseModel):
-    iteration_name: str
-    project_name: str
-    base_path: str
-    is_local: bool
-
-    @field_validator("base_path")
-    def validate_path(cls, value: str) -> str:
-        return validate_and_convert_path(value)
-
-
 class ApplyGraphChangesInput(BaseModel):
     iteration_name: str
     project_name: str

--- a/back/src/changing_dot/optimize_graph.py
+++ b/back/src/changing_dot/optimize_graph.py
@@ -1,10 +1,7 @@
-import uuid
-
 from changing_dot_visualize.observer import Observer
 
 from changing_dot.changing_graph.changing_graph import ChangingGraph
 from changing_dot.checks.merge_cycles import merge_cycles
-from changing_dot.utils.process_pickle_files import process_pickle_files
 
 
 def optimize_graph(G: ChangingGraph, observer: Observer) -> None:
@@ -17,19 +14,3 @@ def optimize_graph(G: ChangingGraph, observer: Observer) -> None:
     G.remove_redundant_edges()
 
     observer.save_graph_state()
-
-
-def run_optimize_graph(
-    iteration_name: str, project_name: str, base_path: str, is_local: bool
-) -> None:
-    job_id = str(uuid.uuid4())
-
-    graphs = process_pickle_files(f"{base_path}/{iteration_name}/", is_local)
-
-    G = ChangingGraph(graphs[-1])
-
-    observer = Observer(
-        G, iteration_name, project_name, job_id=job_id, step=len(graphs)
-    )
-
-    optimize_graph(G, observer)

--- a/back/src/changing_dot/resume_graph.py
+++ b/back/src/changing_dot/resume_graph.py
@@ -27,6 +27,7 @@ from changing_dot.instruction_manager.block_instruction_manager.block_instructio
     create_instruction_manager,
 )
 from changing_dot.modifyle.modifyle import IntegralModifyle
+from changing_dot.optimize_graph import optimize_graph
 from changing_dot.utils.process_pickle_files import process_pickle_files
 
 if TYPE_CHECKING:
@@ -109,3 +110,7 @@ def run_resume_graph(
         observer,
         restriction_options,
     )
+
+    optimize_graph(G, observer)
+
+    observer.log("Finished")

--- a/back/src/changing_dot_cli/cli.py
+++ b/back/src/changing_dot_cli/cli.py
@@ -11,11 +11,9 @@ from changing_dot.create_graph import run_create_graph
 from changing_dot.custom_types import (
     ApplyGraphChangesInput,
     CreateGraphInput,
-    OptimizeGraphInput,
     ResumeGraphInput,
     ResumeInitialNode,
 )
-from changing_dot.optimize_graph import run_optimize_graph
 from changing_dot.resume_graph import run_resume_graph
 from changing_dot_visualize.main import visualize_graph
 from python_analyzer.temporary_venv_creator import create_temporary_venv
@@ -122,25 +120,6 @@ def create(config: str, local: bool, dev: bool) -> None:
 def visualize(config: str, local: bool) -> None:
     config_dict = get_config_dict(config)
     visualize_graph(config_dict, local)
-
-
-@cdot.command()
-@click.option(
-    "--config",
-    "-c",
-    prompt="Path to yaml config file",
-    help="Path to yaml config file.",
-)
-@click.option("--local/--remote", default=True)
-def optimize(config: str, local: bool) -> None:
-    config_dict = get_config_dict(config)
-    optimize_graph_input = OptimizeGraphInput(**config_dict, is_local=local)
-    run_optimize_graph(
-        optimize_graph_input.iteration_name,
-        optimize_graph_input.project_name,
-        optimize_graph_input.base_path,
-        local,
-    )
 
 
 @cdot.command()

--- a/back/tests/core/test_e2e.py
+++ b/back/tests/core/test_e2e.py
@@ -29,7 +29,6 @@ from changing_dot.instruction_manager.hard_coded_instruction_manager import (
     HardCodedInstructionManager,
 )
 from changing_dot.modifyle.modifyle import IntegralModifyle
-from changing_dot.optimize_graph import optimize_graph
 from changing_dot.utils.text_functions import read_text, write_text
 from changing_dot_visualize.observer import Observer
 
@@ -142,9 +141,9 @@ def test_e2e() -> None:
         if os.path.isfile(os.path.join(expected_directory_path, f))
     ]
 
-    assert len(files) == 1
+    assert len(files) == 2
 
-    expected_file_path = "./outputs/tmp/0_test.pickle"
+    expected_file_path = "./outputs/tmp/1_test.pickle"
 
     with open(expected_file_path, "rb") as pickle_file:
         data = pickle.load(pickle_file)
@@ -174,31 +173,6 @@ def test_e2e() -> None:
             "./tests/core/fixtures/base.cs",
         ),
     )
-
-    ### Optimize Graph
-
-    optimize_graph(G, observer)
-
-    ### assert
-
-    expected_directory_path = "./outputs/tmp"
-
-    files = [
-        f
-        for f in os.listdir(expected_directory_path)
-        if os.path.isfile(os.path.join(expected_directory_path, f))
-    ]
-
-    assert len(files) == 2  # add a new optimize step
-
-    expected_file_path = "./outputs/tmp/1_test.pickle"
-
-    with open(expected_file_path, "rb") as pickle_file:
-        data = pickle.load(pickle_file)
-        data_graph = ChangingGraph(data)
-        assert (
-            data_graph.get_number_of_nodes() == 3
-        )  # Same as before since nothing is optimized
 
     # ### Resume graph
 

--- a/back/tests/test_example_configs.py
+++ b/back/tests/test_example_configs.py
@@ -4,7 +4,6 @@ import os
 from changing_dot.custom_types import (
     ApplyGraphChangesInput,
     CreateGraphInput,
-    OptimizeGraphInput,
     ResumeGraphInput,
     ResumeInitialNode,
 )
@@ -17,7 +16,6 @@ def test_example_configs() -> None:
         config_path = os.path.join(example_config_path, file_name)
         config_dict = get_config_dict(config_path)
         _create_graph_input = CreateGraphInput(**config_dict, is_local=True)
-        _optimize_graph_input = OptimizeGraphInput(**config_dict, is_local=True)
         _apply_graph_changes_input = ApplyGraphChangesInput(
             **config_dict, is_local=True
         )


### PR DESCRIPTION
Optimize step isn't very useful at the moment :
- most graphs do not need to be optimized
- it makes sense to always optimize a graph after creating it and resuming it
- it adds another command to the cli adding complexity

In this PR we remove the optimize command from the CLI and automatically run this step after any create and resume step

NB : Merge optimization might not make any sense but this will be heavily impacted by the error manager changes that are in the roadmap, so we keep it here atm